### PR TITLE
Add Script to Monitor CPU Temperature Using AMD Thermal Sensors on OPNsense

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Sample output:
 0 PowerUnitGroup2 - OK - Power Unit Group: 2 Status: Present, OK
 ```
 
+### check cputemp
+
+in order to work this check properly, the amdtemp should be selected under the System > Settings > Miscellaneous > Thermal Sensors > amdtemp
+
 ## Plugins
 The role includes some (optional) plugins
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,23 @@ Sample output:
 
 ### check cputemp
 
-in order to work this check properly, the amdtemp should be selected under the System > Settings > Miscellaneous > Thermal Sensors > amdtemp
+Make sure you configure your OPNsense router as follows:
+
+Modify the /boot/loader.conf file and add the following entries:
+
+coretemp_load="YES" or amdtemp_load="YES"
+It's also acceptable to have both entries in your configuration.
+
+In some cases, if the script does not recognize the thermal sensor, you can manually switch it to either amdtemp or coretemp via the GUI.
+
+To do this, navigate to: System > Settings > Miscellaneous > Thermal Sensors > Hardware
+
+Alternatively, you can set this configuration using the OPNsense role under general settings:
+opn_general:
+  system/webgui/thermal_hardware: "amdtemp"
+
+Troubleshoot the functionality of your thermal sensors by using this command on your opnsense:
+sysctl -a | grep temperature
 
 ## Plugins
 The role includes some (optional) plugins

--- a/files/cputemp.sh
+++ b/files/cputemp.sh
@@ -1,41 +1,42 @@
 #!/usr/local/bin/bash
 
-declare -i ECODE=0
-declare STATUS="OK"
-declare TXT=""
 declare temp_warn=60
 declare temp_crit=80
 
-# Read the temperature from sysctl
-if sysctl -a | grep -q dev.amdtemp.0.core0.sensor0; then
-    temp="$(sysctl -a | grep dev.amdtemp.0.core0.sensor0 | awk '{print $2}' | sed 's/.$//')"
-    STATUS="$temp°C"
+# Function to display temperatures for all found sensors of a specific type
+display_temps() {
+    local sensor_pattern=$1
+    local description=$2
+
+    # Collect all relevant sensor readings
+    sysctl -a | grep -E "$sensor_pattern" | while read sensor_data; do
+        local sensor_id=$(echo $sensor_data | awk '{print $1}')
+        local temp=$(echo $sensor_data | awk '{print $2}' | sed 's/C//')  # Removing 'C' from '44.0C'
+        local temp_int=$(echo "$temp" | awk '{printf "%.0f", $1}')
+        local ECODE=0
+        local TXT="CPU Temp normal"
+
+        # Determine status based on temperature thresholds
+        if (( $(echo "$temp >= $temp_crit" | bc -l) )); then
+            ECODE=2
+            TXT="CPU Temp critical"
+        elif (( $(echo "$temp >= $temp_warn" | bc -l) )); then
+            ECODE=1
+            TXT="CPU Temp warning"
+        fi 
+        echo "$ECODE CPUTEMP - temperature is $temp°C - $TXT"
+    done
+}
+# Main script execution to check different sensor types
+# Check AMD temperature sensors
+if sysctl -a | grep -q 'dev.amdtemp.0.core0.sensor0'; then
+    display_temps 'dev.amdtemp.[0-9]+.core[0-1].sensor[0-1]' "AMD CPU Sensor"
+# Check Intel CPU temperature sensors
+elif sysctl -a | grep -q 'dev.cpu.0.temperature'; then
+    display_temps 'dev.cpu.[0-9]+.temperature' "Intel CPU Sensor"
+# Check PCH temperature sensors, if any
+elif sysctl -a | grep -q 'dev.pchtherm.0.temperature'; then
+    display_temps 'dev.pchtherm.[0-9]+.temperature' "PCH Sensor"
 else
-    # If no temperature is found
-    STATUS="UNKNOWN"
-    ECODE=3
-    TXT="Cannot measure temperature"
+    echo "3 CPUTEMP - UNKNOWN - No thermal sensors found or active"
 fi
-
-# Convert temperature to integer for comparison, if needed
-temp_int=$(echo "$temp" | awk '{printf "%.0f", $1}')
-
-# Debug output
-echo "Temperature read: $temp_float"
-echo "Warning threshold: $temp_warn"
-echo "Critical threshold: $temp_crit"
-
-# Use bc for floating-point comparisons
-if (( $(echo "$temp >= $temp_crit" | bc -l) )); then
-    ECODE=2
-    TXT="CPU Temp critical"
-elif (( $(echo "$temp >= $temp_warn" | bc -l) )); then
-    ECODE=1
-    TXT="CPU Temp warning"
-else
-    TXT="CPU Temp normal"
-fi
-
-# Output result and exit with appropriate code
-echo "$ECODE CPUTEMP - $STATUS - $TXT"
-exit $ECODE

--- a/files/cputemp.sh
+++ b/files/cputemp.sh
@@ -1,0 +1,41 @@
+#!/usr/local/bin/bash
+
+declare -i ECODE=0
+declare STATUS="OK"
+declare TXT=""
+declare temp_warn=60
+declare temp_crit=80
+
+# Read the temperature from sysctl
+if sysctl -a | grep -q dev.amdtemp.0.core0.sensor0; then
+    temp="$(sysctl -a | grep dev.amdtemp.0.core0.sensor0 | awk '{print $2}' | sed 's/.$//')"
+    STATUS="$temp°C"
+else
+    # If no temperature is found
+    STATUS="UNKNOWN"
+    ECODE=3
+    TXT="Cannot measure temperature"
+fi
+
+# Convert temperature to integer for comparison, if needed
+temp_int=$(echo "$temp" | awk '{printf "%.0f", $1}')
+
+# Debug output
+echo "Temperature read: $temp_float"
+echo "Warning threshold: $temp_warn"
+echo "Critical threshold: $temp_crit"
+
+# Use bc for floating-point comparisons
+if (( $(echo "$temp >= $temp_crit" | bc -l) )); then
+    ECODE=2
+    TXT="CPU Temp critical"
+elif (( $(echo "$temp >= $temp_warn" | bc -l) )); then
+    ECODE=1
+    TXT="CPU Temp warning"
+else
+    TXT="CPU Temp normal"
+fi
+
+# Output result and exit with appropriate code
+echo "$ECODE CPUTEMP - $STATUS - $TXT"
+exit $ECODE

--- a/files/cputemp.sh
+++ b/files/cputemp.sh
@@ -6,7 +6,6 @@ declare temp_crit=80
 # Function to display temperatures for all found sensors of a specific type
 display_temps() {
     local sensor_pattern=$1
-    local description=$2
 
     # Collect all relevant sensor readings
     sysctl -a | grep -E "$sensor_pattern" | while read sensor_data; do
@@ -23,20 +22,20 @@ display_temps() {
         elif (( $(echo "$temp >= $temp_warn" | bc -l) )); then
             ECODE=1
             TXT="CPU Temp warning"
-        fi 
-        echo "$ECODE CPUTEMP - temperature is $temp°C - $TXT"
+        fi
+        echo "$ECODE CPUTEMP-$sensor_id - temperature is $temp°C - $TXT"
     done
 }
 # Main script execution to check different sensor types
 # Check AMD temperature sensors
 if sysctl -a | grep -q 'dev.amdtemp.0.core0.sensor0'; then
-    display_temps 'dev.amdtemp.[0-9]+.core[0-1].sensor[0-1]' "AMD CPU Sensor"
+    display_temps 'dev.amdtemp.[0-9]+.core[0-1].sensor[0-1]'
 # Check Intel CPU temperature sensors
 elif sysctl -a | grep -q 'dev.cpu.0.temperature'; then
-    display_temps 'dev.cpu.[0-9]+.temperature' "Intel CPU Sensor"
+    display_temps 'dev.cpu.[0-9]+.temperature'
 # Check PCH temperature sensors, if any
 elif sysctl -a | grep -q 'dev.pchtherm.0.temperature'; then
-    display_temps 'dev.pchtherm.[0-9]+.temperature' "PCH Sensor"
+    display_temps 'dev.pchtherm.[0-9]+.temperature'
 else
     echo "3 CPUTEMP - UNKNOWN - No thermal sensors found or active"
 fi


### PR DESCRIPTION
### Description:
This pull request introduces a new Bash script designed to monitor CPU temperatures using AMD thermal sensors on OPNsense systems. It reads temperature data through sysctl and issues alerts based on set thresholds.

### Changes:

New Script: Implements a script to fetch temperatures from dev.amdtemp.0.core0.sensor0.
Thresholds: Configures warnings at 60°C and critical alerts at 80°C.
Output: Provides detailed outputs including temperature readings, status codes, and contextual alert messages.
### Prerequisites:

Configuration Requirement: Ensure AMD thermal sensors are enabled under System Settings > Miscellaneous > Thermal Sensors > Hardware in OPNsense.
### Rationale: Monitoring CPU temperature is crucial for maintaining hardware integrity and operational stability. This script helps in proactively managing thermal conditions to prevent overheating.

### Testing Conducted:

Environment: Tested on an OPNsense system with configured AMD thermal sensors.
Results: The script successfully identified temperature fluctuations and triggered alerts at defined thresholds.
### Impact: This script will enhance system reliability by enabling administrators to effectively monitor and manage CPU temperatures, thus preventing potential system failures due to overheating.

